### PR TITLE
Use package compiler not x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ using Revise \n\
 RUN julia -E 'using Pkg; \
 Pkg.add(["Atom", "Juno"]); \
 Pkg.add(["Plots", "GR", "PyCall", "DataFrames"]); \
-Pkg.add(PackageSpec(url="https://github.com/KristofferC/PackageCompilerX.jl.git",rev="master")); \
+Pkg.add(PackageSpec(url="https://github.com/JuliaComputing/PackageCompilerX.jl.git",rev="master")); \
 using Atom, Juno, PackageCompilerX; # for precompilation\
 '
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,16 +81,16 @@ using Revise \n\
 RUN julia -E 'using Pkg; \
 Pkg.add(["Atom", "Juno"]); \
 Pkg.add(["Plots", "GR", "PyCall", "DataFrames"]); \
-Pkg.add(PackageSpec(url="https://github.com/JuliaComputing/PackageCompilerX.jl.git",rev="master")); \
-using Atom, Juno, PackageCompilerX; # for precompilation\
+Pkg.add(PackageSpec(url="https://github.com/JuliaLang/PackageCompiler.jl.git",rev="master")); \
+using Atom, Juno, PackageCompiler; # for precompilation\
 '
 
-# Do Ahead of Time Compilation using PackageCompilerX
+# Do Ahead of Time Compilation using PackageCompiler
 # For some technical reason, we switch default user to root then we switch back again
 USER root
 RUN julia --trace-compile="traced.jl" -e 'using OhMyREPL, Revise, Plots, PyCall, DataFrames' && \
-    julia -e 'using PackageCompilerX; \
-              PackageCompilerX.create_sysimage([:OhMyREPL, :Revise, :Plots, :GR, :PyCall, :DataFrames]; precompile_statements_file="traced.jl", replace_default=true) \
+    julia -e 'using PackageCompiler; \
+              PackageCompiler.create_sysimage([:OhMyREPL, :Revise, :Plots, :GR, :PyCall, :DataFrames]; precompile_statements_file="traced.jl", replace_default=true) \
              ' && \
     rm traced.jl
 # Make NB_USER Occupy julia binary

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 - This repository gives us some useful techniques such as:
   1. how to utilize Docker Docker Compose with your Julia workflow.
-  2. how to customize Julia's system image via PackageCompilerX.jl to reduce an overhead of package's loading time e.g. Plots.jl, PyCall.jl, or DataFrames.jl etc...
+  2. how to customize Julia's system image via PackageCompiler.jl to reduce an overhead of package's loading time e.g. Plots.jl, PyCall.jl, or DataFrames.jl etc...
   3. how to share our work on the Internet. Check our repository on Binder from [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/terasakisatoshi/MyWorkflow.jl/master)
   4. how to use GitHub actions as a CI functionality.
 


### PR DESCRIPTION
This PR modifies use NEW PackageCompiler.jl not one of X.jl
- See [Total rewrite of the package (aka make PackageCompilerX the new PackageCompiler) #304](https://github.com/JuliaLang/PackageCompiler.jl/pull/304)
