### PR TITLE
Fix julia project directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,11 +103,17 @@ RUN chown -R ${NB_UID} /usr/local/julia
 USER ${NB_USER}
 
 # Pkgs with respect to Jupyter
+# When initialize jupyter notebook ...
+# Install kernel so that `JULIA_PROJECT` should be ${HOME}
 RUN jupyter nbextension uninstall --user webio/main && \
     jupyter nbextension uninstall --user webio-jupyter-notebook && \
-    julia -e 'using Pkg; Pkg.add(["IJulia", "Interact", "WebIO"]); using WebIO; WebIO.install_jupyter_nbextension()' && \
-    julia -e 'using IJulia, Interact' && \
-    echo Done
+    julia -e 'using Pkg; Pkg.add(["IJulia", "Interact", "WebIO"]); \
+              using WebIO; WebIO.install_jupyter_nbextension(); \
+              using IJulia, Interact; \
+              envhome=ENV["HOME"]; \
+              installkernel("Julia", "--project=$envhome");\
+              ' && \
+    echo "Done"
 
 # Make sure the contents of our repo are in ${HOME}
 WORKDIR ${HOME}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 	rm -f Manifest.toml
 	docker build -t jlatom .
 	docker-compose build
-	docker-compose run --rm julia julia --project=. -e 'using Pkg; Pkg.instantiate()'
+	docker-compose run --rm julia julia --project=/home/jovyan -e 'using Pkg; Pkg.instantiate()'
 
 atom:
 ifeq ($(OS), Linux)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     volumes:
       - ./:/work
     working_dir: /work
-    command: julia --project=.
+    command: julia --project=/home/jovyan
   web:
     build: ./
     container_name: mypackagedocs


### PR DESCRIPTION
- This PR set JULIA_PROJECT as `~/home/jovyan` when you initialize `jupyter notebook`
- if developer runs our docker-compose locally Julia will recognize julia project as `/work` which will occurs import error or developer should activate again which is annoying.
- installkernel("Julia", "--project=/home/jovyan") will solve our problem