### PR TITLE
add texlive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
     xvfb \
     libgtk-3-0 \
     dvipng \
+    texlive-latex-recommended  \
     zip \
     libxt6 libxrender1 libxext6 libgl1-mesa-glx libqt5widgets5 # GR
 


### PR DESCRIPTION
- If we are GR.jl user, we do not have to worry about latex environments. But Plots.jl (even GR backend) has an issue related to latex. 
- AFIK we need install `texlive-latex-recommended`.

c.f. https://github.com/jheinen/GR.jl/issues/300