### PR TITLE
use sympy 1.15.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,11 @@ RUN curl -kL https://bootstrap.pypa.io/get-pip.py | python3 && \
     jupyter-contrib-nbextensions \
     jupyter-nbextensions-configurator \
     jupyterlab_code_formatter autopep8 black \
-    numpy sympy pandas matplotlib numba
+    numpy \
+    sympy==1.5.* \
+    pandas \
+    matplotlib \
+    numba
 
 RUN jupyter notebook --generate-config && \
     echo "\

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -40,11 +40,17 @@ ENV PATH=${HOME}/.local/bin:$PATH
 RUN curl -kL https://bootstrap.pypa.io/get-pip.py | python3 && \
     pip3 install \
     jupyter \
+    jupyterlab \
     jupytext \
     ipywidgets \
     jupyter-contrib-nbextensions \
     jupyter-nbextensions-configurator \
-    numpy sympy pandas matplotlib numba
+    jupyterlab_code_formatter autopep8 black \
+    numpy \
+    sympy==1.5.* \
+    pandas \
+    matplotlib \
+    numba
 
 
 RUN jupyter notebook --generate-config && \


### PR DESCRIPTION
Disable warning something like:

```
importing sympy.matrices.matrices with 'from sympy import *' has been
deprecated since SymPy 1.6. Use import sympy.matrices.matrices
instead. See https://github.com/sympy/sympy/issues/18245 for more
info.
```