### PR TITLE
initialize default image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,8 @@ end\n\
 \n\
 ' >> ${HOME}/.julia/config/startup.jl && cat ${HOME}/.julia/config/startup.jl
 
+RUN julia -e 'using InteractiveUtils; versioninfo()'
+
 WORKDIR /work
 ENV JULIA_PROJECT=/work
 # create Project file at /work


### PR DESCRIPTION
- Since we set `ENV JULIA_PROJECT=/work` before initialize julia runtime, 
Revise, OhMyREPL (which are required to run startup.jl) won't be installed in default environment. During installation process, `Manifest.toml` is stored at `/work` of inside of Docker image. If we mount `/work` from host, the `/work/Manifest.toml` vanishes, which means it causes an error that can't resolve Packages Revise and OhMyREPL.
- The solution is that install Revise OhMyREPL to default environment namely `~/.julia/env/v1.4/Project.toml`. If we run julia via `RUN julia -e ....`, startup.jl tries to install them automatically. 

