### PR TITLE
run build by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ TAG=mac
 REMOTE_DOCKER_REPOSITORY:=terasakisatoshi/${DOCKERIMAGE}:${TAG}
 endif
 
-all: pull
+all: build
 
 pull:
 	rm -f Manifest.toml

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ docker-compose build --parallel
 $ make build
 ```
 
-### Case 4: Using pre-built image
+### Case 4: Using pre-built image (Ubuntu/Mac users only)
 
 ```
 $ make pull


### PR DESCRIPTION
Change the behavior of the "make" command to be equivalent to "make build" because sharing the pre-built system image with other computers may cause unintended errors.