### PR TITLE
Prepare release v0.18.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MyWorkflow"
 uuid = "7abf360e-92cb-4f35-becd-441c2614658a"
 authors = ["Satoshi Terasaki <terasakisatoshi.math@gmail.com>"]
-version = "0.17.0"
+version = "0.18.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 - MyWorkflow.jl master (nightly) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/terasakisatoshi/MyWorkflow.jl/master) Julia v1.5.2
 
-- MyWorkflow.jl v0.17.0 (stable) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/terasakisatoshi/MyWorkflow.jl/v0.17.0) Julia v1.5.1
+- MyWorkflow.jl v0.18.0 (stable) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/terasakisatoshi/MyWorkflow.jl/v0.18.0) Julia v1.5.1
 
 - MyWorkflow.jl v0.15.0 (legacy) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/terasakisatoshi/MyWorkflow.jl/v0.15.0) Julia v1.4.2
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ $ tree .
 │   └── Dockerfile
 ├── docker-compose.yml
 ├── docs
-│   ├── Manifest.toml
 │   ├── Project.toml
 │   ├── make.jl
 │   └── src
@@ -59,6 +58,7 @@ $ tree .
 │       ├── Rotation3D.jl
 │       ├── apply_PCA_to_MNIST.jl
 │       ├── box_and_ball_system.jl
+│       ├── clang.jl
 │       ├── coordinate_system.jl
 │       ├── curve.jl
 │       ├── example.jl
@@ -74,8 +74,10 @@ $ tree .
 │       ├── n-Soliton.jl
 │       ├── ode.jl
 │       ├── plotly_surface.jl
+│       ├── plots_fill_example.jl
 │       ├── plots_sample.jl
 │       ├── pyplot.jl
+│       ├── rcall.jl
 │       ├── seaborn.jl
 │       ├── tangent_space.jl
 │       └── tangent_vector.jl


### PR DESCRIPTION
# Feature

- use Julia-v1.5.2 as a base image #245
- add RCall.jl to run/call R from Julia #256
- bump compat for some packages 
- fix some bugs 
  - #248, #247 (to resolve #246)
- Do not install LazySets v1.37.x #254
- Del unused files #250 