### PR TITLE
bump to 0.19.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MyWorkflow"
 uuid = "7abf360e-92cb-4f35-becd-441c2614658a"
 authors = ["Satoshi Terasaki <terasakisatoshi.math@gmail.com>"]
-version = "0.18.0"
+version = "0.19.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
@@ -121,7 +121,8 @@ Zygote = "0.4, 0.5"
 julia = "1.5"
 
 [extras]
+Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Glob"]

--- a/README.md
+++ b/README.md
@@ -10,10 +10,7 @@
 
 - MyWorkflow.jl master (nightly) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/terasakisatoshi/MyWorkflow.jl/master) Julia v1.5.2
 
-- MyWorkflow.jl v0.18.0 (stable) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/terasakisatoshi/MyWorkflow.jl/v0.18.0) Julia v1.5.2
-
-- MyWorkflow.jl v0.15.0 (legacy) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/terasakisatoshi/MyWorkflow.jl/v0.15.0) Julia v1.4.2
-
+- MyWorkflow.jl v0.18.0 (stable) [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/terasakisatoshi/MyWorkflow.jl/v0.19.0) Julia v1.5.2
 
 # Feature
 


### PR DESCRIPTION
# Feature
  - Add examples regarding to JSXGraph
  - Add example for LazySets.jl
    - Fix compat for LazySets.jl 
  - enable jldoctest
  - Allow to initialize Pluto from Jupyter Notebook/Lab