### PR TITLE
install jupyterlab=2.*

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update && \
 RUN curl -kL https://bootstrap.pypa.io/get-pip.py | python3 && \
     pip3 install \
     jupyter \
-    jupyterlab \
+    jupyterlab==2.* \
     jupytext \
     ipywidgets \
     jupyter-contrib-nbextensions \

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -41,7 +41,7 @@ ENV PATH=${HOME}/.local/bin:$PATH
 RUN curl -kL https://bootstrap.pypa.io/get-pip.py | python3 && \
     pip3 install \
     jupyter \
-    jupyterlab \
+    jupyterlab==2.* \
     jupytext \
     ipywidgets \
     jupyter-contrib-nbextensions \


### PR DESCRIPTION
Force to Install `JupyterLab=2.*`. (Since some extensions do not work for v3)