### PR TITLE
Enable to run on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ endif
 all: build
 
 pull:
-	rm -f Manifest.toml
+	-rm -f Manifest.toml
 	docker pull ${REMOTE_DOCKER_REPOSITORY}
 	docker tag ${REMOTE_DOCKER_REPOSITORY} ${DOCKERIMAGE}
 	docker-compose run --rm julia julia --project=/work -e 'using Pkg; Pkg.instantiate()'
 
 build:
-	rm -f Manifest.toml
+	-rm -f Manifest.toml
 	docker build -t ${DOCKERIMAGE} .
 	docker-compose build
 	docker-compose run --rm julia julia --project=/work -e 'using Pkg; Pkg.instantiate()'
@@ -50,9 +50,9 @@ test: build
 
 clean:
 	docker-compose down
-	rm -f docs/src/weavesample.md
-	rm -f playgound/notebook/*.ipynb
-	rm -rf playgound/notebook/*.gif
-	rm -f  Manifest.toml docs/Manifest.toml
-	rm -rf docs/build
+	-rm -f docs/src/weavesample.md
+	-rm -f playgound/notebook/*.ipynb
+	-rm -rf playgound/notebook/*.gif
+	-rm -f  Manifest.toml docs/Manifest.toml
+	-rm -rf docs/build
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ $ docker run --rm -it julia
 # some staff happens ...
 ```
 
-- It will initialize the fresh Julia environment even if you do not have a Julia on your (host) machine.
+- It will initialize a fresh Julia environment even if you do not have a Julia on your (host) machine.
 
 ## Buiding Docker image
 
@@ -135,6 +135,25 @@ $ rm -f Manifest.toml
 $ docker build -t myworkflojl .
 $ docker-compose build
 $ docker-compose run --rm julia julia --project=/work -e 'using Pkg; Pkg.instantiate()'
+```
+
+### Tips for Windows Users
+
+- You can install `make` command via [winget](https://github.com/microsoft/winget-cli).
+
+```ps
+PS> # open powershell NOT `cmd.exe`
+PS> winget install "Make for Windows" # install `make` command
+PS> make
+```
+
+- Or try the following procedure:
+
+```ps
+PS> Remove-Item -Path Manifest.toml -ErrorAction Ignore
+PS> docker build -t myworkflowjl .
+PS> docker-compose build
+PS> docker-compose run --rm julia julia --project=/work -e 'using Pkg; Pkg.instantiate()'
 ```
 
 ## Pull Docker image (Optional)


### PR DESCRIPTION
I managed to run our project on my windows machine 😅 ...  Here is what I did:

- Install winget-cli to get `make` command
- Use `-rm` instead of `rm` to ignore error on running `rm -f Manifest.toml`. (This error occurs when Manifest.toml does not exist on Windows). By adding `-`, we can ignore the error and go to next command.
  - See: https://www.gnu.org/software/make/manual/html_node/Errors.html
