### PR TITLE
make test-parallel saves your time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.phony : all, pull, build, atom, web, test, clean
+.phony : all, pull, build, atom, web, test, test-parallel, clean
 
 OS:=$(shell uname -s)
 DOCKERIMAGE=myworkflowjl
@@ -47,6 +47,10 @@ web: docs
 test: build
 	docker-compose run --rm julia julia -e 'using Pkg; Pkg.activate("."); Pkg.test()'
 	docker-compose run --rm julia julia -e 'using Pkg; Pkg.activate("."); Pkg.instantiate(); include("playground/test/runtests.jl")'
+
+test-parallel: build
+	docker-compose run --rm julia julia -e 'using Pkg; Pkg.activate("."); Pkg.test()'
+	docker-compose run --rm julia julia -t auto -e 'using Pkg; Pkg.activate("."); Pkg.instantiate(); include("playground/test/runtests.jl")'
 
 clean:
 	docker-compose down

--- a/playground/test/runtests.jl
+++ b/playground/test/runtests.jl
@@ -7,12 +7,13 @@ julia> include("experiments/test/runtests.jl")
 
 using Test
 using Glob
+using Base.Threads
 
 ignore_files = ["wav_example.md", "clang.md", "linear_regression.md"]
 
 @testset "MyWorkflow.jl" begin
     files = glob("*.md", joinpath(@__DIR__, "..", "notebook")) |> sort
-    for f in files
+    @threads for f in files
         basename(f) in ignore_files && continue
         @info "Running $f"
         proc = run(`jupytext --to ipynb --execute $f`)


### PR DESCRIPTION
`$ make test` runs test regarding jupyter notebooks. This PR provides a more efficient task runner `make test-parallel` that runs `jupytext --execute <md-file>` using `Base.Threads`